### PR TITLE
Update Cryptacular version from 1.0 to 1.2.4

### DIFF
--- a/opensaml-parent/pom.xml
+++ b/opensaml-parent/pom.xml
@@ -50,6 +50,7 @@
         <java-support.version>7.3.0-SNAPSHOT</java-support.version>
         <spring-extensions.version>5.3.0-SNAPSHOT</spring-extensions.version>
         <checkstyle.configLocation>${project.basedir}/../opensaml-parent/resources/checkstyle/checkstyle.xml</checkstyle.configLocation>
+        <cryptacular.version>1.2.4</cryptacular.version>
     </properties>
 
     <repositories>
@@ -118,7 +119,11 @@
               <artifactId>spymemcached</artifactId>
               <version>2.11.4</version>
           </dependency>
-
+          <dependency>
+              <groupId>org.cryptacular</groupId>
+              <artifactId>cryptacular</artifactId>
+              <version>${cryptacular.version}</version>
+          </dependency>
             <!-- Provided Dependencies -->
 
             <!-- Runtime Dependencies -->


### PR DESCRIPTION
Hi,

Thanks for this open-source project.

The project Cryptacular is vulnerable to CVE-2020-7226, for details see [1]

This is mitigated in Cryptacular version 1.2.4 [2]

Regards,
Manjunath

1. https://nvd.nist.gov/vuln/detail/CVE-2020-7226
2. https://github.com/vt-middleware/cryptacular/issues/52